### PR TITLE
Fe feat/common thumbnail 컴포넌트 작업

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,5 +1,7 @@
+import ThumbnailBox from './components/ui/thumbnail/ThumbnailBox';
+
 const App = () => {
-  return <>HI</>;
+  return <ThumbnailBox />;
 };
 
 export default App;

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,7 +1,35 @@
 import ThumbnailBox from './components/ui/thumbnail/ThumbnailBox';
+import cssToken from './styles/cssToken';
 
 const App = () => {
-  return <ThumbnailBox />;
+  return (
+    <>
+      <ThumbnailBox
+        styles={{
+          width: '100%',
+          height: '0',
+          borderRadius: cssToken.BORDER['rounded-s'],
+        }}
+        src="https://www.sungsimdangmall.co.kr/data/sungsimdang/goods/sungsimdang/big/202310454292163523295.jpg"
+      />
+      <br />
+      <ThumbnailBox
+        styles={{
+          width: '312px',
+          height: '184px',
+        }}
+        src="https://www.sungsimdangmall.co.kr/data/sungsimdang/goods/sungsimdang/big/202310454292163523295.jpg"
+      />
+      <br />
+      <ThumbnailBox
+        styles={{
+          width: '437px',
+          height: '238px',
+        }}
+        src="https://www.sungsimdangmall.co.kr/data/sungsimdang/goods/sungsimdang/big/202310454292163523295.jpg"
+      />
+    </>
+  );
 };
 
 export default App;

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,35 +1,5 @@
-import ThumbnailBox from './components/ui/thumbnail/ThumbnailBox';
-import cssToken from './styles/cssToken';
-
 const App = () => {
-  return (
-    <>
-      <ThumbnailBox
-        styles={{
-          width: '100%',
-          height: '0',
-          borderRadius: cssToken.BORDER['rounded-s'],
-        }}
-        src="https://www.sungsimdangmall.co.kr/data/sungsimdang/goods/sungsimdang/big/202310454292163523295.jpg"
-      />
-      <br />
-      <ThumbnailBox
-        styles={{
-          width: '312px',
-          height: '184px',
-        }}
-        src="https://www.sungsimdangmall.co.kr/data/sungsimdang/goods/sungsimdang/big/202310454292163523295.jpg"
-      />
-      <br />
-      <ThumbnailBox
-        styles={{
-          width: '437px',
-          height: '238px',
-        }}
-        src="https://www.sungsimdangmall.co.kr/data/sungsimdang/goods/sungsimdang/big/202310454292163523295.jpg"
-      />
-    </>
-  );
+  return <>HI</>;
 };
 
 export default App;

--- a/client/src/components/ui/thumbnail/ThumbnailBox.tsx
+++ b/client/src/components/ui/thumbnail/ThumbnailBox.tsx
@@ -37,7 +37,7 @@ export const Img = styled.img`
 const ThumbnailBox = ({ src, styles }: Thumbnail) => {
   return (
     <ThumbnailContainer {...styles}>
-      <Img src={src} />
+      <Img src={src} alt="ThumbnailImg" />
     </ThumbnailContainer>
   );
 };

--- a/client/src/components/ui/thumbnail/ThumbnailBox.tsx
+++ b/client/src/components/ui/thumbnail/ThumbnailBox.tsx
@@ -1,5 +1,33 @@
+import styled from 'styled-components';
+
+import cssToken from '../../../styles/cssToken';
+
+const ThumbnailContainer = styled.div`
+  position: relative;
+  border-radius: ${cssToken.BORDER['rounded-s']};
+  overflow: hidden;
+  width: ${cssToken.WIDTH['w-full']};
+  height: 0;
+  padding-bottom: 50%;
+`;
+
+export const Img = styled.img`
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  object-fit: cover;
+  width: ${cssToken.WIDTH['w-full']};
+  height: ${cssToken.HEIGHT['h-full']};
+`;
+
 const ThumbnailBox = () => {
-  return <>dfdf</>;
+  return (
+    <ThumbnailContainer>
+      <Img src="https://www.sungsimdangmall.co.kr/data/sungsimdang/goods/sungsimdang/big/202310454292163523295.jpg" />
+    </ThumbnailContainer>
+  );
 };
 
 export default ThumbnailBox;

--- a/client/src/components/ui/thumbnail/ThumbnailBox.tsx
+++ b/client/src/components/ui/thumbnail/ThumbnailBox.tsx
@@ -2,13 +2,25 @@ import styled from 'styled-components';
 
 import cssToken from '../../../styles/cssToken';
 
-const ThumbnailContainer = styled.div`
+type ThumbnailStyle = {
+  width?: string;
+  height?: string;
+  borderRadius?: string;
+};
+
+interface Thumbnail {
+  styles?: ThumbnailStyle;
+  src?: string;
+  alt?: string;
+}
+
+const ThumbnailContainer = styled.div<ThumbnailStyle>`
   position: relative;
-  border-radius: ${cssToken.BORDER['rounded-s']};
+  border-radius: ${(props) => (props.borderRadius ? props.borderRadius : '0')};
   overflow: hidden;
-  width: ${cssToken.WIDTH['w-full']};
-  height: 0;
-  padding-bottom: 50%;
+  width: ${(props) => (props.width ? props.width : '100%')};
+  height: ${(props) => (props.height ? props.height : '0')};
+  padding-bottom: ${(props) => (props.height === '0' ? '50%' : 'auto')};
 `;
 
 export const Img = styled.img`
@@ -22,10 +34,10 @@ export const Img = styled.img`
   height: ${cssToken.HEIGHT['h-full']};
 `;
 
-const ThumbnailBox = () => {
+const ThumbnailBox = ({ src, styles }: Thumbnail) => {
   return (
-    <ThumbnailContainer>
-      <Img src="https://www.sungsimdangmall.co.kr/data/sungsimdang/goods/sungsimdang/big/202310454292163523295.jpg" />
+    <ThumbnailContainer {...styles}>
+      <Img src={src} />
     </ThumbnailContainer>
   );
 };

--- a/client/src/components/ui/thumbnail/ThumbnailBox.tsx
+++ b/client/src/components/ui/thumbnail/ThumbnailBox.tsx
@@ -1,0 +1,5 @@
+const ThumbnailBox = () => {
+  return <>dfdf</>;
+};
+
+export default ThumbnailBox;


### PR DESCRIPTION
# 🔗 작업 요구서 : https://github.com/codestates-seb/seb44_main_006/issues/2#issue-1784445065
- 카드 컴포넌트에 들어가는 썸네일은 넓이 100%로 지정했습니다.
- 다른 컴포넌트의 경우 넓이 px 입니다. (추후 %로 변경 될 수도 있습니다.)

## 작업 화면
![스크린샷 2023-07-03 오후 7 51 29](https://github.com/codestates-seb/seb44_main_006/assets/109754988/24995e94-186f-427b-9b7c-52993a137214)

## 적용 예시
```
return (
    <>
      <ThumbnailBox
        styles={{
          width: '100%',
          height: '0',
          borderRadius: cssToken.BORDER['rounded-s'],
        }}
        src="https://www.sungsimdangmall.co.kr/data/sungsimdang/goods/sungsimdang/big/202310454292163523295.jpg"
      />
   
      <ThumbnailBox
        styles={{
          width: '312px',
          height: '184px',
        }}
        src="https://www.sungsimdangmall.co.kr/data/sungsimdang/goods/sungsimdang/big/202310454292163523295.jpg"
      />
    
      <ThumbnailBox
        styles={{
          width: '437px',
          height: '238px',
        }}
        src="https://www.sungsimdangmall.co.kr/data/sungsimdang/goods/sungsimdang/big/202310454292163523295.jpg"
      />
    </>
  );
```
