### PR TITLE
Be feat/login 토큰 예외처리 세분화

### DIFF
--- a/server/src/main/java/com/seb_main_006/config/SecurityConfiguration.java
+++ b/server/src/main/java/com/seb_main_006/config/SecurityConfiguration.java
@@ -54,7 +54,7 @@ public class SecurityConfiguration {
                 .formLogin().disable()
                 .httpBasic().disable()
                 .exceptionHandling()
-                .authenticationEntryPoint(new MemberAuthenticationEntryPoint())  // (1) 추가
+                .authenticationEntryPoint(new MemberAuthenticationEntryPoint(jwtTokenizer))  // (1) 추가
                 .accessDeniedHandler(new MemberAccessDeniedHandler())
                 .and()
                 .apply(new CustomFilterConfigurer())
@@ -96,7 +96,7 @@ public class SecurityConfiguration {
             AuthenticationManager authenticationManager = builder.getSharedObject(AuthenticationManager.class);
 
             // JWT 토큰 검증 필터 생성 및 필터 순서 설정 : 인증(일반로그인 or 소셜로그인) 필터 다음에 적용
-            JwtVerificationFilter jwtVerificationFilter = new JwtVerificationFilter(jwtTokenizer, redisUtil, authorityUtils);
+            JwtVerificationFilter jwtVerificationFilter = new JwtVerificationFilter(jwtTokenizer, redisUtil, authorityUtils, refreshTokenRedisRepository);
 
             builder.addFilterAfter(jwtVerificationFilter, OAuth2LoginAuthenticationFilter.class)
                     .addFilterAfter(jwtVerificationFilter, UsernamePasswordAuthenticationFilter.class);

--- a/server/src/main/java/com/seb_main_006/global/auth/controller/AuthController.java
+++ b/server/src/main/java/com/seb_main_006/global/auth/controller/AuthController.java
@@ -2,6 +2,7 @@ package com.seb_main_006.global.auth.controller;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seb_main_006.global.auth.service.AuthService;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -13,6 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+@Slf4j
 @RestController
 @RequestMapping("/auth")
 public class AuthController {
@@ -29,6 +31,8 @@ public class AuthController {
         String accessToken = request.getHeader("Authorization").replace("Bearer ", "");
         String refreshToken = request.getHeader("RefreshToken");
 
+        // TODO: ADMIN 계정일 경우 로그아웃 시키지 않기?
+
         authService.logout(accessToken, refreshToken);
 
         return new ResponseEntity<>(HttpStatus.OK);
@@ -37,12 +41,11 @@ public class AuthController {
     @PostMapping("/reissue")
     public ResponseEntity reissue(HttpServletRequest request,
                                   HttpServletResponse response,
-                                  @AuthenticationPrincipal(expression = "username") String email) throws JsonProcessingException {
-        System.out.println("AuthController.reissue");
-        System.out.println("email = " + email);
+                                  @AuthenticationPrincipal(expression = "username") String userEmail) throws JsonProcessingException {
+        log.info("userEmail = {}", userEmail);
 
         String refreshToken = request.getHeader("RefreshToken");
-        String newAccessToken = authService.reissue(refreshToken);
+        String newAccessToken = authService.reissue(refreshToken, userEmail);
 
         // 응답 헤더에 재발급된 AccessToken 추가
         response.setHeader("Authorization", "Bearer " + newAccessToken);

--- a/server/src/main/java/com/seb_main_006/global/auth/filter/JwtVerificationFilter.java
+++ b/server/src/main/java/com/seb_main_006/global/auth/filter/JwtVerificationFilter.java
@@ -73,7 +73,8 @@ public class JwtVerificationFilter extends OncePerRequestFilter {
             System.out.println("check1");
             if (redisUtil.hasKeyBlackList(token)) {
                 System.out.println("check2");
-                throw new RuntimeException("다시 로그인 하십시오.");
+                ErrorResponder.sendErrorResponse(response, ExceptionCode.TOKEN_EXPIRED);
+                return;
             }
 
             verifyJws(request, token);// 토큰 유효성 검증

--- a/server/src/main/java/com/seb_main_006/global/auth/filter/JwtVerificationFilter.java
+++ b/server/src/main/java/com/seb_main_006/global/auth/filter/JwtVerificationFilter.java
@@ -3,11 +3,19 @@ package com.seb_main_006.global.auth.filter;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.seb_main_006.global.auth.jwt.JwtTokenizer;
 import com.seb_main_006.global.auth.redis.RedisUtil;
+import com.seb_main_006.global.auth.redis.RefreshToken;
+import com.seb_main_006.global.auth.redis.RefreshTokenRedisRepository;
 import com.seb_main_006.global.auth.utils.CustomAuthorityUtils;
+import com.seb_main_006.global.auth.utils.ErrorResponder;
+import com.seb_main_006.global.exception.BusinessLogicException;
+import com.seb_main_006.global.exception.ExceptionCode;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.security.SignatureException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.InsufficientAuthenticationException;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -15,40 +23,50 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 
+import javax.security.sasl.AuthenticationException;
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 //클라이언트 측에서 전송된 request header 에 포함된 JWT 에 대해 검증 작업을 수행하는 클래스
+@Slf4j
 public class JwtVerificationFilter extends OncePerRequestFilter {
     private final JwtTokenizer jwtTokenizer;
     private final RedisUtil redisUtil;
     private final CustomAuthorityUtils authorityUtils;
+    private final RefreshTokenRedisRepository refreshTokenRedisRepository;
 
-    public JwtVerificationFilter(JwtTokenizer jwtTokenizer, RedisUtil redisUtil, CustomAuthorityUtils authorityUtils) {
+    public JwtVerificationFilter(JwtTokenizer jwtTokenizer, RedisUtil redisUtil, CustomAuthorityUtils authorityUtils, RefreshTokenRedisRepository refreshTokenRedisRepository) {
         this.jwtTokenizer = jwtTokenizer;
         this.redisUtil = redisUtil;
         this.authorityUtils = authorityUtils;
+        this.refreshTokenRedisRepository = refreshTokenRedisRepository;
     }
 
     // JWT 를 검증하고 Authentication 객체를 SecurityContext 에 저장하기 위한 private 메서드
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
-        System.out.println("JwtVerificationFilter.doFilterInternal");
+        log.info("requestURI = {}", request.getRequestURI());
 
-        System.out.println("request.getRequestURI() = " + request.getRequestURI()); // 왜 /auth/reissue 만 /login 으로 바뀌는지? /auth/test 는 잘 동작하는데...
+        boolean isReissue = request.getRequestURI().equals("/auth/reissue");
+        String token = "";
+
+        if (request.getHeader("Authorization") == null || request.getHeader("Authorization").replaceAll("Bearer ", "").length() == 0) {
+            ErrorResponder.sendErrorResponse(response, ExceptionCode.IM_A_TEAPOT);
+            return;
+        }
 
         try {
-            String token = "";
-            if (!request.getRequestURI().equals("/auth/reissue")) {
-                System.out.println("check00");
+            if (!isReissue) {
+                System.out.println("check: not reissue");
                 token = request.getHeader("Authorization").replace("Bearer ", "");
             } else {
-                System.out.println("check01");
+                System.out.println("check: reissue");
                 token = request.getHeader("RefreshToken");
             }
 
@@ -58,13 +76,21 @@ public class JwtVerificationFilter extends OncePerRequestFilter {
                 throw new RuntimeException("다시 로그인 하십시오.");
             }
 
-            verifyJws(request);// 토큰 유효성 검증
-            System.out.println("check3");
-            setAuthenticationToContext(token);
+            verifyJws(request, token);// 토큰 유효성 검증
+            setAuthenticationToContext(token, isReissue);
+
         } catch (SignatureException se) {
-            request.setAttribute("exception", se);
-        } catch (ExpiredJwtException ee) { //만료된 것은 추가처리 필요함
+            request.setAttribute("signatureException", se);
+        } catch (ExpiredJwtException ee) {
+            log.info("expiredJwtException 발생");
             request.setAttribute("exception", ee);
+            ErrorResponder.sendErrorResponse(response, ExceptionCode.TOKEN_EXPIRED);
+            return;
+        } catch (IllegalArgumentException ie) {
+            log.info("IllegalArgumentException 발생(토큰 없음)");
+            request.setAttribute("exception", ie);
+            ErrorResponder.sendErrorResponse(response, ExceptionCode.IM_A_TEAPOT);
+            return;
         } catch (Exception e) {
             request.setAttribute("exception", e);
         }
@@ -74,37 +100,43 @@ public class JwtVerificationFilter extends OncePerRequestFilter {
     }
 
     //조건에 부합하지 않으면 이 필터를 적용하지 않고 다음 필터로 넘어감
-    @Override
-    protected boolean shouldNotFilter(HttpServletRequest request) {
-        String authorization = request.getHeader("Authorization"); // 잘못된 헤더 요청 시 예외 처리 어떻게?
-        String refreshToken = request.getHeader("RefreshToken");
-
-        return authorization == null;
-    }
+//    @Override
+//    protected boolean shouldNotFilter(HttpServletRequest request) {
+//        String authorization = request.getHeader("Authorization"); // 잘못된 헤더 요청 시 예외 처리 어떻게?
+//        String refreshToken = request.getHeader("RefreshToken");
+//
+//        return authorization == null;
+//    }
 
     //JWT 를 검증하는 데 사용되는 private 메서드
-    private Map<String, Object> verifyJws(HttpServletRequest request) {
-        String jws = request.getHeader("Authorization").replace("Bearer ", "");
+    private Map<String, Object> verifyJws(HttpServletRequest request, String token) {
+//        String jws = request.getHeader("Authorization").replace("Bearer ", "");
         String base64EncodedSecretKey = jwtTokenizer.encodeBase64SecretKey(jwtTokenizer.getSecretKey());
 
-        return jwtTokenizer.getClaims(jws, base64EncodedSecretKey).getBody();
+        return jwtTokenizer.getClaims(token, base64EncodedSecretKey).getBody();
     }
 
     //Authentication 객체를 SecurityContext 에 저장하기 위한 private 메서드
-    protected void setAuthenticationToContext(String token) throws JsonProcessingException {
+    protected void setAuthenticationToContext(String token, Boolean isReissue) throws JsonProcessingException {
         System.out.println("check6");
         Jws<Claims> claims = jwtTokenizer.getClaims(token);
-        System.out.println("check7");
-        List<String> roles = (List<String>) claims.getBody().get("roles"); // 문제 발생
-        System.out.println("roles = " + roles); // roles = null 왜???????? 왜 /auth/reissue 일 때만???
-        System.out.println("check8");
-        List<GrantedAuthority> authorities = authorityUtils.createAuthorities(roles);
-        System.out.println("check9");
+        List<String> roles = null;
+        String username = null;
 
-        UserDetails principal = new User(claims.getBody().get("username").toString(), "", authorities);
-        System.out.println("check10");
+        if (isReissue) {
+            RefreshToken refreshTokenInfo = refreshTokenRedisRepository.findByRefreshToken(token);
+            roles = refreshTokenInfo.getAuthorities();
+            username = refreshTokenInfo.getUsername();
+        } else {
+            roles = (List<String>) claims.getBody().get("roles");
+            username = claims.getBody().get("username").toString();
+        }
+
+        System.out.println("roles = " + roles);
+        List<GrantedAuthority> authorities = authorityUtils.createAuthorities(roles);
+
+        UserDetails principal = new User(username, "", authorities);
         UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(principal, "", authorities);
-        System.out.println("check11");
         SecurityContextHolder.getContext().setAuthentication(authenticationToken);
     }
 

--- a/server/src/main/java/com/seb_main_006/global/auth/handler/MemberAuthenticationEntryPoint.java
+++ b/server/src/main/java/com/seb_main_006/global/auth/handler/MemberAuthenticationEntryPoint.java
@@ -1,6 +1,10 @@
 package com.seb_main_006.global.auth.handler;
 
+import com.seb_main_006.global.auth.jwt.JwtTokenizer;
+import com.seb_main_006.global.auth.jwt.Subject;
 import com.seb_main_006.global.auth.utils.ErrorResponder;
+import io.jsonwebtoken.ExpiredJwtException;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.AuthenticationException;
@@ -14,10 +18,15 @@ import java.io.IOException;
 
 @Slf4j
 @Component
+@RequiredArgsConstructor
 public class MemberAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final JwtTokenizer jwtTokenizer;
+
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
         Exception exception = (Exception) request.getAttribute("exception");
+
         ErrorResponder.sendErrorResponse(response, HttpStatus.UNAUTHORIZED);
 
         logExceptionMessage(authException, exception);
@@ -25,6 +34,7 @@ public class MemberAuthenticationEntryPoint implements AuthenticationEntryPoint 
 
     private void logExceptionMessage(AuthenticationException authException, Exception exception) {
         String message = exception != null ? exception.getMessage() : authException.getMessage();
-        log.warn("Unauthorized error happened: {}", message);
+        String errorClassName = exception != null ? exception.getClass().getName() : authException.getClass().getName();
+        log.warn("Unauthorized error happened: {}-{}", message, errorClassName);
     }
 }

--- a/server/src/main/java/com/seb_main_006/global/auth/service/AuthService.java
+++ b/server/src/main/java/com/seb_main_006/global/auth/service/AuthService.java
@@ -9,13 +9,14 @@ import com.seb_main_006.global.auth.redis.RefreshTokenRedisRepository;
 import com.seb_main_006.global.exception.BusinessLogicException;
 import com.seb_main_006.global.exception.ExceptionCode;
 import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.ExpiredJwtException;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.time.Instant;
 import java.util.List;
 
+@Slf4j
 @Service
 public class AuthService {
     private final RefreshTokenRedisRepository refreshTokenRedisRepository;
@@ -31,8 +32,8 @@ public class AuthService {
         this.jwtTokenizer = jwtTokenizer;
     }
 
-    public void logout(String accessToken, String refreshToken) throws JsonProcessingException {
-        System.out.println("AuthService.logout");
+    public void logout(String accessToken, String refreshToken) {
+        log.info("accessToken = {}, refreshToken = {}", accessToken, refreshToken);
 
         // refreshToken 테이블의 refreshToken 삭제
         RefreshToken findRefreshToken = refreshTokenRedisRepository.findByRefreshToken(refreshToken);
@@ -51,27 +52,18 @@ public class AuthService {
         redisUtil.setBlackList(accessToken, "accessToken", remainingTime);
     }
 
-    public String reissue(String refreshToken) throws JsonProcessingException {
-        System.out.println("AuthService.reissue");
+    public String reissue(String refreshToken, String userEmail) throws JsonProcessingException {
+        log.info("refreshToken = {}", refreshToken);
 
-        Subject subject = null;
+        String tokenType = jwtTokenizer.getSubject(refreshToken).getTokenType();
 
-        if (refreshToken == null) { //RefreshToken 이 비어있을시 에러
-            throw new BusinessLogicException(ExceptionCode.IM_A_TEAPOT);
-        }
-        try { //RefreshToken 이 만료시 에러
-            subject = jwtTokenizer.getSubject(refreshToken);
-        } catch (ExpiredJwtException e) {
-            throw new BusinessLogicException(ExceptionCode.TOKEN_EXPIRED);
-        }
-        if (!subject.getTokenType().equals("RefreshToken")) { // "RefreshToken" 이 아님 -> 에러 메세지 + 418 status 리턴
+        if (!tokenType.equals("RefreshToken")) { // "RefreshToken" 이 아님 -> 에러 메세지 + 418 status 리턴
             throw new BusinessLogicException(ExceptionCode.IM_A_TEAPOT);
         }
 
         // "RefreshToken" 인 경우 -> AccessToken 재발급 후 리턴
-        String username = subject.getUsername(); // 유저 email
         List<String> authorities = refreshTokenRedisRepository.findByRefreshToken(refreshToken).getAuthorities();
 
-        return jwtTokenizer.generateAccessToken(username, authorities);
+        return jwtTokenizer.generateAccessToken(userEmail, authorities);
     }
 }

--- a/server/src/main/java/com/seb_main_006/global/auth/utils/ErrorResponder.java
+++ b/server/src/main/java/com/seb_main_006/global/auth/utils/ErrorResponder.java
@@ -1,6 +1,7 @@
 package com.seb_main_006.global.auth.utils;
 
 import com.google.gson.Gson;
+import com.seb_main_006.global.exception.ExceptionCode;
 import com.seb_main_006.global.response.ErrorResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -13,7 +14,17 @@ public class ErrorResponder {
         Gson gson = new Gson();
         ErrorResponse errorResponse = ErrorResponse.of(status);
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
         response.setStatus(status.value());
+        response.getWriter().write(gson.toJson(errorResponse, ErrorResponse.class));
+    }
+
+    public static void sendErrorResponse(HttpServletResponse response, ExceptionCode status) throws IOException {
+        Gson gson = new Gson();
+        ErrorResponse errorResponse = ErrorResponse.of(status);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+        response.setStatus(status.getStatus());
         response.getWriter().write(gson.toJson(errorResponse, ErrorResponse.class));
     }
 }

--- a/server/src/main/java/com/seb_main_006/global/exception/ExceptionCode.java
+++ b/server/src/main/java/com/seb_main_006/global/exception/ExceptionCode.java
@@ -18,11 +18,8 @@ public enum ExceptionCode {
     ANSWER_CANNOT_CHANGE(403,"답변을 수정 할 수 없습니다."),
     ANSWER_CANNOT_DELETE(403,"답변을 삭제 할 수 없습니다."),
     NOT_IMPLEMENTATION(501,"Not Implementation"),
-    TOKEN_EXPIRED(401,"토큰이 만료되었습니다. 다시 로그인해주세요."),
+    TOKEN_EXPIRED(444,"토큰이 만료되었습니다. 다시 로그인해주세요."),
     IM_A_TEAPOT(418,"주전자가 비어있습니다. 커피를 넣어주세요");
-
-
-
 
 
     @Getter

--- a/server/src/main/resources/application-local.properties
+++ b/server/src/main/resources/application-local.properties
@@ -11,7 +11,7 @@ spring.jpa.properties.hibernate.format_sql=true
 
 jwt.key = ${JWT_SECRET_KEY}
 jwt.access-token-expiration-minutes=50000
-jwt.refresh-token-expiration-minutes=420
+jwt.refresh-token-expiration-minutes=20160
 mail.address.admin=admin@email.com
 
 ## GOOGLE Login


### PR DESCRIPTION
## 4XX 상태코드
- 444 : 토큰 만료 (일반 API 시 AccessToken 만료, reissue API 호출 시 RefreshToken 만료), 로그아웃된 토큰일 경우
- 418 : Auhorization 헤더나 RefreshToken 헤더 값이 존재하지 않거나 비어 있는 경우
- 401 : 그 밖의 일반적인 토큰 유효성 검사 실패
<br>

## JwtVerificationFilter 의 shouldNotFilter() 메서드 미사용
- Authorization 헤더가 null 인 경우 필터 건너 뛰도록 되어 있었는데 이 경우 500 에러가 발생함. 
- 그래서 JwtVerificationFilter에서 이 경우도 핸들링하고 shouldNotFilter() 메서드 주석처리 상태
<br>

## reissue API 호출 시 JwtVerificationFilter 를 통과하지 못하던 문제 해결
- refreshToken 일 경우 roles 이 담겨있지 않아서 SecrutiyContextHolder 에 담기 위한 roles 을 가져오는 부분에서 문제가 발생했던 것
- setAuthenticationToContext() 메서드 내에서 refreshToken 일 경우와 accessToken 일 경우 roles 을 가져오는 로직 분리
- reissue 엔드포인트 요청도 JwtVerificationFilter 에서 처리하면서 기존 AuthService 에서 처리하던 예외처리 중복되는 부분 제거
<br>

#### JwtVerificationFilter 자체에서 예외를 핸들링하는 로직이 많아서 코드가 너무 지저분해지는 것 같아 리팩토링이 필요하다고 생각되는데... 방향을 못 잡겠습니다....😭