### PR TITLE
feat: 로그인 예외처리 로직 수정

### DIFF
--- a/server/src/main/java/com/seb_main_006/domain/member/entity/Member.java
+++ b/server/src/main/java/com/seb_main_006/domain/member/entity/Member.java
@@ -34,6 +34,9 @@ public class Member {
     @Enumerated(EnumType.STRING)
     private MemberStatus memberStatus = MemberStatus.ACTIVE; // 회원 활동 상태, 기본값이 활동중
 
+    @Enumerated(EnumType.STRING)
+    private Provider memberProvider; // 회원 활동 상태, 기본값이 활동중
+
     @ElementCollection(fetch = FetchType.EAGER)
     private List<String> roles = new ArrayList<>(); // 계정권한(admin, user)
 
@@ -50,10 +53,24 @@ public class Member {
     private List<Bookmark> bookmarksInMember = new ArrayList<>(); // bookmark entity와 연관관계 매핑(1:다)
 
     //로그인 할때 소셜에서 받아온 값들 저장용
-    public Member(String email, String nickname, String imgURL) {
+    public Member(String email, String nickname, String imgURL, String provider) {
         this.memberEmail = email;
         this.memberNickname = nickname;
         this.memberImageUrl = imgURL;
+
+        switch (provider) {
+            case "google":
+                this.memberProvider = Provider.GOOGLE;
+                break;
+            case "naver":
+                this.memberProvider = Provider.NAVER;
+                break;
+            case "kakao":
+                this.memberProvider = Provider.KAKAO;
+                break;
+            default:
+                this.memberProvider = null;
+        }
     }
 
     @Getter
@@ -61,4 +78,8 @@ public class Member {
         ACTIVE, DELETED;
     }
 
+    @Getter
+    public enum Provider {
+        GOOGLE, NAVER, KAKAO;
+    }
 }

--- a/server/src/main/java/com/seb_main_006/domain/member/service/MemberService.java
+++ b/server/src/main/java/com/seb_main_006/domain/member/service/MemberService.java
@@ -22,17 +22,36 @@ public class MemberService {
         this.customAuthorityUtils = customAuthorityUtils;
     }
 
-    // 구글 로그인 회원 가입
+    // 소셜 로그인 회원 가입
     public Member createMember(Member member) {
-        if (!verifyExistEmail(member.getMemberEmail())) { // DB에 이메일이 존재하지 않을 때만 회원 가입 로직 수행
+
+        // DB에 이메일이 존재하지 않을 때만 회원 가입 로직 수행
+        if (!verifyExistEmail(member.getMemberEmail())) {
 
             // DB에 member Role 저장
             List<String> roles = customAuthorityUtils.createRoles(member.getMemberEmail());
             member.setRoles(roles);
 
-            member = memberRepository.save(member);
+            return memberRepository.save(member);
         }
-        return member;
+
+        // DB에 이메일(계정)이 존재하면 DB에 저장된 Member 반환
+        return findExistMember(member.getMemberEmail());
+    }
+
+
+    // 이메일로 DB에서 회원을 조회하고, 현재 가입된 provider 정보 String으로 반환
+    // (GOOGLE, NAVER, KAKAO, null), OAuth2MemberSuccessHandler에서 호출
+    public String findExistEmailAndDiffProvider(String userEmail, String currentProvider) {
+
+        Optional<Member> optionalMember = memberRepository.findByMemberEmail(userEmail);
+
+        // DB에 이메일(가입된 계정)이 존재하고, 그 계정의 provider가 현재 로그인하려는 provider와 같을 경우에는 null 로 반환
+        // handler에서 예외 처리 로직을 타지 않도록 하기 위함
+        if (optionalMember.isPresent() && optionalMember.get().getMemberProvider().toString().equalsIgnoreCase(currentProvider)) {
+            return null;
+        }
+        return optionalMember.isEmpty() ? null : optionalMember.get().getMemberProvider().toString();
     }
 
     private boolean verifyExistEmail(String userEmail) {
@@ -40,10 +59,16 @@ public class MemberService {
         Optional<Member> user= memberRepository.findByMemberEmail(userEmail);
         return user.isPresent();
     }
+
+    private Member findExistMember(String userEmail) {
+
+        Optional<Member> optionalMember = memberRepository.findByMemberEmail(userEmail);
+        return optionalMember.isEmpty() ? null : optionalMember.get();
+    }
+
     public Member findVerifiedMember(String memberEmail) {
         return memberRepository.findByMemberEmail(memberEmail)
                 .orElseThrow(() -> new BusinessLogicException(ExceptionCode.MEMBER_NOT_FOUND));
-
     }
 
 }

--- a/server/src/main/java/com/seb_main_006/global/auth/service/CustomOAuth2UserService.java
+++ b/server/src/main/java/com/seb_main_006/global/auth/service/CustomOAuth2UserService.java
@@ -32,19 +32,14 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
         // userRequest를 통해 사용자의 정보를 추출
         String registrationId = userRequest.getClientRegistration().getRegistrationId(); // OAuth 서비스 이름(ex. google, kakao)
 
-
-
         String userNameAttributeName = userRequest.getClientRegistration() // OAuth 로그인 시 키(pk)가 되는 값 ex) sub(google), id(kakao), id(naver)
                 .getProviderDetails().getUserInfoEndpoint().getUserNameAttributeName();
 
         OAuth2Attribute oAuth2Attribute =
                 OAuth2Attribute.of(registrationId, userNameAttributeName, oAuth2User.getAttributes());
 
-
-
         var userAttribute = oAuth2Attribute.convertToMap();
-
-
+        log.info("provider = {}", userAttribute.get("provider")); // google, naver, kakao
 
         // Spring Seucirty의 OAuth2User 구현체를 생성하여 반환(OAuth2UserSuccessHanlder에 사용할 예정)
         return new DefaultOAuth2User(

--- a/server/src/main/java/com/seb_main_006/global/exception/ExceptionCode.java
+++ b/server/src/main/java/com/seb_main_006/global/exception/ExceptionCode.java
@@ -1,6 +1,7 @@
 package com.seb_main_006.global.exception;
 
 import lombok.Getter;
+import lombok.Setter;
 
 public enum ExceptionCode {
     MEMBER_NOT_FOUND(404,"사용자를 찾을 수 없습니다."),
@@ -19,13 +20,18 @@ public enum ExceptionCode {
     ANSWER_CANNOT_DELETE(403,"답변을 삭제 할 수 없습니다."),
     NOT_IMPLEMENTATION(501,"Not Implementation"),
     TOKEN_EXPIRED(444,"토큰이 만료되었습니다. 다시 로그인해주세요."),
-    IM_A_TEAPOT(418,"주전자가 비어있습니다. 커피를 넣어주세요");
+    IM_A_TEAPOT(418,"주전자가 비어있습니다. 커피를 넣어주세요"),
+    GOOGLE_ACCOUNT_EXISTS(409,"이미 구글로 가입된 사용자입니다."),
+    NAVER_ACCOUNT_EXISTS(409,"이미 네이버로 가입된 사용자입니다."),
+    KAKAO_ACCOUNT_EXISTS(409,"이미 카카오로 가입된 사용자입니다.");
+
 
 
     @Getter
     private int status;
 
     @Getter
+    @Setter
     private String message;
 
     ExceptionCode(int code, String message) {

--- a/server/src/main/resources/application-local.properties
+++ b/server/src/main/resources/application-local.properties
@@ -6,7 +6,7 @@ spring.datasource.password=${MYSQL_PASSWORD}
 spring.jpa.show-sql=true
 spring.jpa.database=mysql
 spring.jpa.database-platform=org.hibernate.dialect.MySQL5InnoDBDialect
-spring.jpa.hibernate.ddl-auto=update
+spring.jpa.hibernate.ddl-auto=create
 spring.jpa.properties.hibernate.format_sql=true
 
 jwt.key = ${JWT_SECRET_KEY}


### PR DESCRIPTION
- 동일 이메일, 다른 플랫폼으로 이미 가입된 계정이 있을 경우 예외 메세지와 함께 예외 발생 (409)
- 멤버 엔티티에 Provider 필드 추가