### PR TITLE
feat: 회원 탈퇴 기능 구현

### DIFF
--- a/server/src/main/java/com/seb_main_006/config/SecurityConfiguration.java
+++ b/server/src/main/java/com/seb_main_006/config/SecurityConfiguration.java
@@ -67,6 +67,8 @@ public class SecurityConfiguration {
                         .antMatchers(HttpMethod.DELETE, "/courses/**").hasAnyRole("USER","ADMIN")
 //                        .antMatchers(HttpMethod.POST, "/posts").hasAnyRole("USER","ADMIN")
                         .antMatchers(HttpMethod.DELETE, "/posts/**").hasAnyRole("USER","ADMIN")
+                        .antMatchers(HttpMethod.PATCH, "/members").hasAnyRole("USER","ADMIN")
+                        .antMatchers(HttpMethod.DELETE, "/members").hasAnyRole("USER","ADMIN")
                         .anyRequest().permitAll()
                 )
                 .oauth2Login(oauth2 -> oauth2

--- a/server/src/main/java/com/seb_main_006/domain/member/controller/MemberController.java
+++ b/server/src/main/java/com/seb_main_006/domain/member/controller/MemberController.java
@@ -8,10 +8,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @RestController
@@ -28,6 +25,13 @@ public class MemberController {
 
         memberService.updateMember(memberPatchDto, memberEmail);
         return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+    @DeleteMapping
+    public ResponseEntity deleteMember(@AuthenticationPrincipal(expression = "username") String memberEmail) {
+
+        memberService.deleteMember(memberEmail);
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 
 }

--- a/server/src/main/java/com/seb_main_006/domain/member/entity/Member.java
+++ b/server/src/main/java/com/seb_main_006/domain/member/entity/Member.java
@@ -86,4 +86,13 @@ public class Member {
     public enum Provider {
         GOOGLE, NAVER, KAKAO;
     }
+
+    // 탈퇴한 유저 재가입 (기존 정보를 신규 가입 정보로 변경)
+    public void activateMember(Member newMember) {
+        this.setMemberStatus(Member.MemberStatus.ACTIVE);
+        this.setMemberNickname(newMember.getMemberNickname());
+        this.setRoles(newMember.getRoles());
+        this.setMemberImageUrl(newMember.getMemberImageUrl());
+        this.setMemberProvider(newMember.getMemberProvider());
+    }
 }

--- a/server/src/main/java/com/seb_main_006/domain/member/repository/MemberRepository.java
+++ b/server/src/main/java/com/seb_main_006/domain/member/repository/MemberRepository.java
@@ -2,10 +2,15 @@ package com.seb_main_006.domain.member.repository;
 
 import com.seb_main_006.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository <Member, Long> {
 
+    @Query("select m from Member m where m.memberEmail=:memberEmail and m.memberStatus='ACTIVE'")
     Optional<Member> findByMemberEmail(String memberEmail);
+
+    @Query("select m from Member m where m.memberEmail=:memberEmail and m.memberStatus='DELETED'")
+    Optional<Member> findDeletedUserByMemberEmail(String memberEmail);
 }

--- a/server/src/main/java/com/seb_main_006/domain/post/dto/PostDataForList.java
+++ b/server/src/main/java/com/seb_main_006/domain/post/dto/PostDataForList.java
@@ -20,7 +20,7 @@ public class PostDataForList {
     private Long courseId;
     private Long postId;
     private String courseTitle;
-    private String courseContent;
+    private String postContent;
     private String courseThumbnail;
     private String memberNickname;
     private Long courseLikeCount; // 받은 좋아요 수
@@ -35,7 +35,7 @@ public class PostDataForList {
                 .courseId(course.getCourseId())
                 .postId(course.getPost().getPostId())
                 .courseTitle(course.getCourseTitle())
-                .courseContent(course.getCourseContent())
+                .postContent(course.getPost().getPostContent())
                 .courseThumbnail(course.getCourseThumbnail())
                 .memberNickname(course.getMember().getMemberNickname())
                 .courseLikeCount(course.getCourseLikeCount())

--- a/server/src/main/java/com/seb_main_006/global/auth/handler/OAuth2MemberSuccessHandler.java
+++ b/server/src/main/java/com/seb_main_006/global/auth/handler/OAuth2MemberSuccessHandler.java
@@ -153,7 +153,7 @@ public class OAuth2MemberSuccessHandler extends SimpleUrlAuthenticationSuccessHa
                 .newInstance()
                 .scheme("http")
                 .host("localhost")
-//                .port(5173)
+                .port(5173)
                 .queryParams(queryParams)
                 .build()
                 .toUri();

--- a/server/src/main/java/com/seb_main_006/global/auth/service/AuthService.java
+++ b/server/src/main/java/com/seb_main_006/global/auth/service/AuthService.java
@@ -13,7 +13,6 @@ import com.seb_main_006.global.auth.redis.RefreshTokenRedisRepository;
 import com.seb_main_006.global.exception.BusinessLogicException;
 import com.seb_main_006.global.exception.ExceptionCode;
 import io.jsonwebtoken.Claims;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -61,6 +60,9 @@ public class AuthService {
         redisUtil.setBlackList(accessToken, "accessToken", remainingTime);
     }
 
+    /**
+     * AccessToken 재발급
+     */
     public String reissue(String refreshToken, String userEmail) throws JsonProcessingException {
         log.info("refreshToken = {}", refreshToken);
 
@@ -76,12 +78,19 @@ public class AuthService {
         return jwtTokenizer.generateAccessToken(userEmail, authorities);
     }
 
+    /**
+     * 프론트 저장용 유저 정보 조회
+     */
     public MemberInfoResponseDto getMemberInfo(String accessToken) throws JsonProcessingException {
         String memberEmail = jwtTokenizer.getSubject(accessToken).getUsername();
-        Member findMember = memberService.findVerifiedMember(memberEmail);
+        Member findMember = memberService.findExistMember(memberEmail);
+
+        if (findMember == null) {
+            return new MemberInfoResponseDto();
+        }
+
         int myCourseCount = findMember.getCourses().size();
         int myBookmarkCount = bookmarkService.getBookmarkCount(findMember);
-
         return MemberInfoResponseDto.of(findMember, myCourseCount, myBookmarkCount);
     }
 }


### PR DESCRIPTION
- 시큐리티 redirectURI localhost:5173으로 수정
- 탈퇴한 회원 재가입시 탈퇴계정 정보를 활성화하고 현재 가입정보로 세팅
- 태그로 게시글 리스트 조회할 때 courseContent -> postContent 내용이 보이도록 수정 및 필드명 수정
