### PR TITLE
feat: 태그 검색 시 여러 단어 검색 가능하도록 구현

### DIFF
--- a/server/src/main/java/com/seb_main_006/domain/post/service/PostService.java
+++ b/server/src/main/java/com/seb_main_006/domain/post/service/PostService.java
@@ -167,16 +167,14 @@ public class PostService {
 
         // 입력받은 태그 String 을 공백 기준으로 분리
         String[] inputTags = tagName.split(" ");
-        for (String inputTag : inputTags) {
-            log.info("inputTag = {}", inputTag);
-        }
 
         if (tagName == null) {
-            pageResult = courseRepository.findAllByPosted(true, PageRequest.of(page, limit, Sort.by(sort == null ? "courseUpdatedAt" : "courseLikeCount").descending()));
+            PageRequest pageRequest = PageRequest.of(page, limit, Sort.by(sort == null ? "courseUpdatedAt" : "courseLikeCount").descending());
+            pageResult = courseRepository.findAllByPosted(true, pageRequest);
         } else {
             // 각각의 tagName 으로 tag 찾은 후, 찾은 태그들을 Set으로 통합 (중복 제거)
             Set<Tag> findTagSet = new HashSet<>();
-
+            
             for (String inputTag : inputTags) {
                 findTagSet.addAll(tagRepository.findByTagNameContaining(inputTag));
             }
@@ -277,6 +275,7 @@ public class PostService {
     }
 
 
+    // 해당 Course 로 등록된 게시글이 존재하는지 확인 (존재하지 않을 경우 예외 발생)
     public void verifyNoExistPost(Course course) {
         postRepository.findByCourse(course).orElseThrow(() -> new BusinessLogicException(ExceptionCode.CANT_LIKE_NOT_FOUND));
     }

--- a/server/src/main/java/com/seb_main_006/domain/post/service/PostService.java
+++ b/server/src/main/java/com/seb_main_006/domain/post/service/PostService.java
@@ -164,6 +164,8 @@ public class PostService {
         }
 
         Page<Course> pageResult = null;
+
+        // 입력받은 태그 String 을 공백 기준으로 분리
         String[] inputTags = tagName.split(" ");
         for (String inputTag : inputTags) {
             log.info("inputTag = {}", inputTag);
@@ -172,7 +174,7 @@ public class PostService {
         if (tagName == null) {
             pageResult = courseRepository.findAllByPosted(true, PageRequest.of(page, limit, Sort.by(sort == null ? "courseUpdatedAt" : "courseLikeCount").descending()));
         } else {
-            // tagName 으로 tag 찾은 후, 해당 태그들을 가진 Course Page로 조회
+            // 각각의 tagName 으로 tag 찾은 후, 찾은 태그들을 Set으로 통합 (중복 제거)
             Set<Tag> findTagSet = new HashSet<>();
 
             for (String inputTag : inputTags) {
@@ -203,7 +205,7 @@ public class PostService {
     }
 
     /**
-     * 태그로 게시글 조회
+     * 태그로 게시글  (미사용)
      */
     public PostListResponseDto getPostListByTag(String tagName, int page, int limit, String sort, String accessToken) {
         log.info("tagName = {}", tagName);
@@ -248,6 +250,7 @@ public class PostService {
 
         return new PostListResponseDto(postDataList, pageResult);
     }
+
 
     /**
      * 게시글 삭제

--- a/server/src/main/java/com/seb_main_006/domain/post/service/PostService.java
+++ b/server/src/main/java/com/seb_main_006/domain/post/service/PostService.java
@@ -34,9 +34,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -153,7 +151,6 @@ public class PostService {
      */
     public PostListResponseDto findPosts(int page, int limit, String sort, String accessToken, String tagName) {
 
-
         Member member = new Member(0L);
 
         // 리스트 조회시 토큰 비어있을 떄랑 잘못 됐을 때 예외 모두 통과시키기
@@ -167,20 +164,28 @@ public class PostService {
         }
 
         Page<Course> pageResult = null;
+        String[] inputTags = tagName.split(" ");
+        for (String inputTag : inputTags) {
+            log.info("inputTag = {}", inputTag);
+        }
 
         if (tagName == null) {
             pageResult = courseRepository.findAllByPosted(true, PageRequest.of(page, limit, Sort.by(sort == null ? "courseUpdatedAt" : "courseLikeCount").descending()));
         } else {
             // tagName 으로 tag 찾은 후, 해당 태그들을 가진 Course Page로 조회
-            List<Tag> findTagList = tagRepository.findByTagNameContaining(tagName);
+            Set<Tag> findTagSet = new HashSet<>();
+
+            for (String inputTag : inputTags) {
+                findTagSet.addAll(tagRepository.findByTagNameContaining(inputTag));
+            }
 
             // sort 값 여부에 따라 다른 메서드(정렬기준) 적용
             if (sort == null) {
                 log.info("sort == null");
-                pageResult = postTagRepository.findByTagInOrderByUpdatedAt(findTagList, PageRequest.of(page, limit));
+                pageResult = postTagRepository.findByTagInOrderByUpdatedAt(new ArrayList<>(findTagSet), PageRequest.of(page, limit));
             } else {
                 log.info("sort != null (like)");
-                pageResult = postTagRepository.findByTagInOrderByLikeCount(findTagList, PageRequest.of(page, limit));
+                pageResult = postTagRepository.findByTagInOrderByLikeCount(new ArrayList<>(findTagSet), PageRequest.of(page, limit));
             }
         }
 

--- a/server/src/main/java/com/seb_main_006/domain/tag/entity/Tag.java
+++ b/server/src/main/java/com/seb_main_006/domain/tag/entity/Tag.java
@@ -20,11 +20,23 @@ public class Tag {
     @Column(columnDefinition = "TEXT")
     private String tagName; // 태그 이름
 
-//    @OneToMany(mappedBy = "tag")
-//    private List<PostTag> postTagsInTag = new ArrayList<>(); // postTag entity와 연관관계 매핑(1:다)/ 양방향이 아니라 단방향으로 바꾸면서 제거
-
     public Tag(String tagName){
         this.tagName = tagName;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        Tag tag = (Tag) o;
+
+        return Objects.equals(tagName, tag.tagName);
+    }
+
+    @Override
+    public int hashCode() {
+        return tagName != null ? tagName.hashCode() : 0;
     }
 }
 

--- a/server/src/main/java/com/seb_main_006/domain/tag/repository/TagRepository.java
+++ b/server/src/main/java/com/seb_main_006/domain/tag/repository/TagRepository.java
@@ -14,7 +14,4 @@ public interface TagRepository extends JpaRepository<Tag, Long> {
     Optional<Tag> findByTagName(String tagName);
 
     List<Tag> findByTagNameContaining(String tagName);
-
-//    @Query("select distinct t from Tag t where t.tagName like :tagNames and t.tagName in :tagNames ")
-//    List<Tag> findByTagNameContainingV2(List<String> tagNames);
 }

--- a/server/src/main/resources/application-local.properties
+++ b/server/src/main/resources/application-local.properties
@@ -6,7 +6,7 @@ spring.datasource.password=${MYSQL_PASSWORD}
 spring.jpa.show-sql=true
 spring.jpa.database=mysql
 spring.jpa.database-platform=org.hibernate.dialect.MySQL5InnoDBDialect
-spring.jpa.hibernate.ddl-auto=create
+spring.jpa.hibernate.ddl-auto=update
 spring.jpa.properties.hibernate.format_sql=true
 
 jwt.key = ${JWT_SECRET_KEY}


### PR DESCRIPTION
- 쿼리 파라미터 태그(tagName) 전달 받을 때 공백을 기준으로 여러 태그를 하나의 String으로 전달받고,
- 전달받은 여러 태그에 대한 결과 모두 응답
- 입력받은 단어들의 결과가 중복으로 표시되지 않도록 처리
- 태그에 대한 정렬기준은 따로 없는 상태 (기존의 정렬 조건에 따름 - 좋아요 / 최신순)
![image](https://github.com/codestates-seb/seb44_main_006/assets/124571603/9671e5dc-e9da-4114-8e1c-40006074df47)
![image](https://github.com/codestates-seb/seb44_main_006/assets/124571603/a7cded9b-ced1-4c12-8048-e8d387a886d6)
