### PR TITLE
feat: 일정 카드 드래그 앤 드랍 구현

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -13,6 +13,7 @@
         "@types/uuid": "^9.0.2",
         "axios": "^1.4.0",
         "react": "^18.2.0",
+        "react-beautiful-dnd": "^13.1.1",
         "react-datepicker": "^4.15.0",
         "react-dom": "^18.2.0",
         "react-intersection-observer": "^9.5.2",
@@ -26,6 +27,7 @@
       },
       "devDependencies": {
         "@types/react": "^18.0.37",
+        "@types/react-beautiful-dnd": "^13.1.4",
         "@types/react-datepicker": "^4.11.2",
         "@types/react-dom": "^18.0.11",
         "@typescript-eslint/eslint-plugin": "^5.59.0",
@@ -2631,6 +2633,15 @@
         "csstype": "^3.0.2"
       }
     },
+    "node_modules/@types/react-beautiful-dnd": {
+      "version": "13.1.4",
+      "resolved": "https://registry.npmjs.org/@types/react-beautiful-dnd/-/react-beautiful-dnd-13.1.4.tgz",
+      "integrity": "sha512-4bIBdzOr0aavN+88q3C7Pgz+xkb7tz3whORYrmSj77wfVEMfiWiooIwVWFR7KM2e+uGTe5BVrXqSfb0aHeflJA==",
+      "dev": true,
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
     "node_modules/@types/react-datepicker": {
       "version": "4.11.2",
       "resolved": "https://registry.npmjs.org/@types/react-datepicker/-/react-datepicker-4.11.2.tgz",
@@ -2650,6 +2661,17 @@
       "devOptional": true,
       "dependencies": {
         "@types/react": "*"
+      }
+    },
+    "node_modules/@types/react-redux": {
+      "version": "7.1.25",
+      "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.25.tgz",
+      "integrity": "sha512-bAGh4e+w5D8dajd6InASVIyCo4pZLJ66oLb80F9OBLO1gKESbZcRCJpTT6uLXX+HAB57zw1WTdwJdAsewuTweg==",
+      "dependencies": {
+        "@types/hoist-non-react-statics": "^3.3.0",
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0",
+        "redux": "^4.0.0"
       }
     },
     "node_modules/@types/scheduler": {
@@ -3449,6 +3471,14 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-box-model": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/css-box-model/-/css-box-model-1.2.1.tgz",
+      "integrity": "sha512-a7Vr4Q/kd/aw96bnJG332W9V9LkJO69JRcaCYDUqjp6/z0w6VcZjgAcTbgFxEPfBgdnAwlh3iwu+hLopa+flJw==",
+      "dependencies": {
+        "tiny-invariant": "^1.0.6"
       }
     },
     "node_modules/css-color-keywords": {
@@ -6185,6 +6215,11 @@
       "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.1.2.tgz",
       "integrity": "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig=="
     },
+    "node_modules/raf-schd": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/raf-schd/-/raf-schd-4.0.3.tgz",
+      "integrity": "sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ=="
+    },
     "node_modules/react": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
@@ -6194,6 +6229,53 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-beautiful-dnd": {
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/react-beautiful-dnd/-/react-beautiful-dnd-13.1.1.tgz",
+      "integrity": "sha512-0Lvs4tq2VcrEjEgDXHjT98r+63drkKEgqyxdA7qD3mvKwga6a5SscbdLPO2IExotU1jW8L0Ksdl0Cj2AF67nPQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.9.2",
+        "css-box-model": "^1.2.0",
+        "memoize-one": "^5.1.1",
+        "raf-schd": "^4.0.2",
+        "react-redux": "^7.2.0",
+        "redux": "^4.0.4",
+        "use-memo-one": "^1.1.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.5 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.5 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/react-beautiful-dnd/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
+    },
+    "node_modules/react-beautiful-dnd/node_modules/react-redux": {
+      "version": "7.2.9",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.9.tgz",
+      "integrity": "sha512-Gx4L3uM182jEEayZfRbI/G11ZpYdNAnBs70lFVMNdHJI76XYtR+7m0MN+eAs7UHBPhWXcnFPaS+9owSCJQHNpQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.15.4",
+        "@types/react-redux": "^7.1.20",
+        "hoist-non-react-statics": "^3.3.2",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.7.2",
+        "react-is": "^17.0.2"
+      },
+      "peerDependencies": {
+        "react": "^16.8.3 || ^17 || ^18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-datepicker": {
@@ -7033,6 +7115,11 @@
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.1.tgz",
+      "integrity": "sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw=="
+    },
     "node_modules/titleize": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/titleize/-/titleize-3.0.0.tgz",
@@ -7258,6 +7345,14 @@
       "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-memo-one": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/use-memo-one/-/use-memo-one-1.1.3.tgz",
+      "integrity": "sha512-g66/K7ZQGYrI6dy8GLpVcMsBp4s17xNkYJVSMvTEevGy3nDxHOfE6z8BVE22+5G5x7t3+bhzrlTDB7ObrEE0cQ==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/use-sync-external-store": {

--- a/client/package.json
+++ b/client/package.json
@@ -15,6 +15,7 @@
     "@types/uuid": "^9.0.2",
     "axios": "^1.4.0",
     "react": "^18.2.0",
+    "react-beautiful-dnd": "^13.1.1",
     "react-datepicker": "^4.15.0",
     "react-dom": "^18.2.0",
     "react-intersection-observer": "^9.5.2",
@@ -28,6 +29,7 @@
   },
   "devDependencies": {
     "@types/react": "^18.0.37",
+    "@types/react-beautiful-dnd": "^13.1.4",
     "@types/react-datepicker": "^4.11.2",
     "@types/react-dom": "^18.0.11",
     "@typescript-eslint/eslint-plugin": "^5.59.0",

--- a/client/src/assets/ThreeLine.tsx
+++ b/client/src/assets/ThreeLine.tsx
@@ -1,0 +1,17 @@
+import { IconStyle } from '../types/type';
+
+const ThreeLine = ({ style }: { style: IconStyle }) => {
+  return (
+    <svg
+      width={style.iconWidth}
+      height={style.iconHeight}
+      viewBox="0 0 17 11"
+      fill={style.color}
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path d="M0 1V0H17V1H0ZM17 5V6H0V5H17ZM0 10H17V11H0V10Z" fill="black" />
+    </svg>
+  );
+};
+
+export default ThreeLine;

--- a/client/src/components/map/KakaoMap.tsx
+++ b/client/src/components/map/KakaoMap.tsx
@@ -40,6 +40,7 @@ const KakaoMap = ({
       const newMap = new kakao.maps.Map(element, {
         level,
         center: new kakao.maps.LatLng(Number(lat), Number(lng)),
+        keyboardShortcuts: true,
       });
       dispatch(mapActions.setMap(newMap));
       setState(true);

--- a/client/src/components/map/Polyline.tsx
+++ b/client/src/components/map/Polyline.tsx
@@ -15,7 +15,7 @@ const Polyline = ({ linePos }: { linePos: { lat: string; lng: string }[] }) => {
     const polyline = new kakao.maps.Polyline({
       path: linePath,
       strokeWeight: 8,
-      strokeColor: cssToken.COLOR['point-900'],
+      strokeColor: cssToken.COLOR['polyline-color'],
       strokeOpacity: 1,
       strokeStyle: 'shortdot',
     });

--- a/client/src/components/schedule/ScheduleListBox.tsx
+++ b/client/src/components/schedule/ScheduleListBox.tsx
@@ -1,27 +1,89 @@
 import { styled } from 'styled-components';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
+import {
+  DragDropContext,
+  Draggable,
+  DropResult,
+  Droppable,
+} from 'react-beautiful-dnd';
+import { useEffect, useState } from 'react';
 
 import cssToken from '../../styles/cssToken';
 import { RootState } from '../../store';
 import MapLocationCard from '../ui/cards/MapLocationCard';
-import { IScheduleListItem } from '../../types/type';
+import { IScheduleListItem, TScheduleList } from '../../types/type';
+import { scheduleListActions } from '../../store/scheduleList-slice';
 
 const Wrapper = styled.div`
   width: ${cssToken.WIDTH['w-full']};
 `;
 
 const ScheduleListBox = () => {
+  const dispatch = useDispatch();
   const schedules = useSelector((state: RootState) => state.scheduleList.list);
+
+  const onDragEnd = ({ source, destination }: DropResult) => {
+    if (!destination) return;
+
+    const copySchedules = JSON.parse(
+      JSON.stringify(schedules)
+    ) as TScheduleList;
+    const targetSchedules = copySchedules.splice(source.index, 1);
+    copySchedules.splice(destination.index, 0, ...targetSchedules);
+
+    dispatch(scheduleListActions.updateList(copySchedules));
+  };
+
+  // requestAnimationFrame 초기화
+  const [enabled, setEnabled] = useState(false);
+
+  useEffect(() => {
+    const animation = requestAnimationFrame(() => setEnabled(true));
+
+    return () => {
+      cancelAnimationFrame(animation);
+      setEnabled(false);
+    };
+  }, []);
+
+  if (!enabled) {
+    return null;
+  }
+  // requestAnimationFrame 초기화 END
+
   return (
-    <Wrapper>
-      {schedules.map((schedule: IScheduleListItem, idx: number) => (
-        <MapLocationCard
-          indexNum={idx + 1}
-          location={schedule.placeName}
-          id={schedule.id}
-        />
-      ))}
-    </Wrapper>
+    <DragDropContext onDragEnd={onDragEnd}>
+      <Wrapper>
+        <Droppable key="schedules" droppableId="schedules">
+          {(provided) => (
+            <div ref={provided.innerRef} {...provided.droppableProps}>
+              {schedules.map((schedule: IScheduleListItem, idx: number) => (
+                <Draggable
+                  key={schedule.id}
+                  draggableId={schedule.id}
+                  index={idx}
+                >
+                  {(provided_two) => (
+                    <div
+                      ref={provided_two.innerRef}
+                      {...provided_two.draggableProps}
+                      {...provided_two.dragHandleProps}
+                    >
+                      <MapLocationCard
+                        indexNum={idx + 1}
+                        location={schedule.placeName}
+                        id={schedule.id}
+                      />
+                    </div>
+                  )}
+                </Draggable>
+              ))}
+              {provided.placeholder}
+            </div>
+          )}
+        </Droppable>
+      </Wrapper>
+    </DragDropContext>
   );
 };
 

--- a/client/src/components/ui/cards/MapLocationCard.tsx
+++ b/client/src/components/ui/cards/MapLocationCard.tsx
@@ -10,6 +10,7 @@ import Button from '../button/Button';
 import Trash from '../../../assets/Trash';
 import { scheduleListActions } from '../../../store/scheduleList-slice';
 import { markerActions } from '../../../store/marker-slice';
+import ThreeLine from '../../../assets/ThreeLine';
 
 const MapLocationCardContainer = styled.section`
   display: flex;
@@ -53,13 +54,21 @@ const LocationCard = styled.div<{ selected?: boolean }>`
   align-items: center;
   flex: 1;
   width: ${cssToken.WIDTH['w-full']};
-  padding: ${cssToken.SPACING['gap-24']};
+  padding: ${cssToken.SPACING['gap-24']} ${cssToken.SPACING['gap-12']}
+    ${cssToken.SPACING['gap-24']} ${cssToken.SPACING['gap-16']};
   ${CardCommonBox}
 `;
 
 const LocationText = styled.p`
   font-size: ${cssToken.TEXT_SIZE['text-18']};
   font-weight: ${cssToken.FONT_WEIGHT.medium};
+`;
+
+const RightButtonArea = styled.section`
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+  align-items: center;
 `;
 
 const MapLocationCard = ({ indexNum, location, id }: MapLocationCardInfo) => {
@@ -89,13 +98,16 @@ const MapLocationCard = ({ indexNum, location, id }: MapLocationCardInfo) => {
         }}
       >
         <LocationText>{location}</LocationText>
-        <Button
-          onClick={() => {
-            if (id) handleDelete(id);
-          }}
-        >
-          <Trash style={{ iconWidth: 16, iconHeight: 18 }} />
-        </Button>
+        <RightButtonArea>
+          <ThreeLine style={{ iconWidth: 17, iconHeight: 18 }} />
+          <Button
+            onClick={() => {
+              if (id) handleDelete(id);
+            }}
+          >
+            <Trash style={{ iconWidth: 16, iconHeight: 18 }} />
+          </Button>
+        </RightButtonArea>
       </LocationCard>
     </MapLocationCardContainer>
   );

--- a/client/src/components/ui/cards/MapLocationCard.tsx
+++ b/client/src/components/ui/cards/MapLocationCard.tsx
@@ -47,6 +47,7 @@ const NumCircle = styled.span`
 `;
 
 const LocationCard = styled.div<{ selected?: boolean }>`
+  background-color: ${cssToken.COLOR.white};
   display: flex;
   justify-content: space-between;
   align-items: center;

--- a/client/src/hooks/useKeywordSearch.ts
+++ b/client/src/hooks/useKeywordSearch.ts
@@ -25,8 +25,7 @@ const useKeywordSearch = (
           const [dx, dy] = [data.x, data.y];
           bounds.extend(new kakao.maps.LatLng(Number(dy), Number(dx)));
         }
-
-        map.setBounds(bounds);
+        map.panTo(bounds);
       }
 
       if (datas.length) {

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -20,25 +20,23 @@ import MyPage from './pages/mypage/MyPage';
 const queryClient = new QueryClient();
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
-  <React.StrictMode>
-    <BrowserRouter>
-      <GlobalStyle />
-      <QueryClientProvider client={queryClient}>
-        <Provider store={store}>
-          <Header />
-          <Routes>
-            <Route path="/" element={<Main />} />
-            <Route path="/register" element={<ScheduleRegister />} />
-            <Route path="/community" element={<CommunityPage />} />
-            <Route path="/community/select" element={<SelectSchedulePage />} />
-            <Route path="/community/post" element={<PostCommunitypage />} />
-            <Route path="/community/:postId" element={<DetailPage />} />
-            <Route path="/mypage" element={<MyPage />} />
-            <Route path="/error/:status" element={<ErrorPage />} />
-          </Routes>
-          <App />
-        </Provider>
-      </QueryClientProvider>
-    </BrowserRouter>
-  </React.StrictMode>
+  <BrowserRouter>
+    <GlobalStyle />
+    <QueryClientProvider client={queryClient}>
+      <Provider store={store}>
+        <Header />
+        <Routes>
+          <Route path="/" element={<Main />} />
+          <Route path="/register" element={<ScheduleRegister />} />
+          <Route path="/community" element={<CommunityPage />} />
+          <Route path="/community/select" element={<SelectSchedulePage />} />
+          <Route path="/community/post" element={<PostCommunitypage />} />
+          <Route path="/community/:postId" element={<DetailPage />} />
+          <Route path="/mypage" element={<MyPage />} />
+          <Route path="/error/:status" element={<ErrorPage />} />
+        </Routes>
+        <App />
+      </Provider>
+    </QueryClientProvider>
+  </BrowserRouter>
 );

--- a/client/src/store/scheduleList-slice.ts
+++ b/client/src/store/scheduleList-slice.ts
@@ -49,6 +49,9 @@ const scheduleListSlice = createSlice({
     deletePlace(state, action: PayloadAction<string>) {
       state.list = state.list.filter((obj) => obj.id !== action.payload);
     },
+    updateList(state, action: PayloadAction<TScheduleList>) {
+      state.list = action.payload;
+    },
     resetList(state) {
       state.list = [];
       state.imageUrl = '';

--- a/client/src/styles/cssToken.ts
+++ b/client/src/styles/cssToken.ts
@@ -24,6 +24,7 @@ const cssToken = {
     'gray-700': '#D3D3D3',
     'gray-500': '#E6E6E6',
     'gray-300': '#F8F8F8',
+    'polyline-color': '#009EDC',
     black: '#000',
     white: '#fff',
   },


### PR DESCRIPTION
## 스크린샷
![드래그앤드랍구현](https://github.com/codestates-seb/seb44_main_006/assets/77836614/9854a297-7e35-4000-8857-a7c53a937a8e)

## 작업사항
- react-beautiful-dnd 라이브러리를 활용하여 일정을 드래그로 변경할 수 있게 구현했습니다.

## 그 외 작업사항
- 일정 카드, polyline 스타일을 수정했습니다.
- 지도가 움직일 때 딱딱하던 애니메이션을 부드럽게 수정했습니다.
- 키보드로 지도를 확대 / 축소할 수 있게 수정했습니다.
- 일정 카드에 드래그 가능한 것을 나타내는 아이콘 추가했습니다.