### PR TITLE
FE-feat - feat: 마이페이지 수정

### DIFF
--- a/client/src/components/mypage/FilterSection.tsx
+++ b/client/src/components/mypage/FilterSection.tsx
@@ -2,6 +2,7 @@ import { styled } from 'styled-components';
 import { useInView } from 'react-intersection-observer';
 import { useNavigate } from 'react-router-dom';
 
+import SkeletonCardContainer from '../community/skeleton/SkeletonCardContainer';
 import ContensCard from '../ui/cards/ContentsCard';
 import cssToken from '../../styles/cssToken';
 import { CardWrapper, FlexDiv } from '../../styles/styles';
@@ -101,50 +102,61 @@ const FilterSection = ({
 
       <CardWrapper>
         {memberCourseList && selectTab === 'First'
-          ? memberCourseList?.map((post: MypCourseSummaryT) => (
-              <ContensCard
-                key={post.courseId}
-                type="course"
-                title={post.courseTitle}
-                likeCount={post.courseLikeCount}
-                userName={post.memberNickname}
-                thumbnail={post.courseThumbnail}
-                onClick={moveToRegisterDetail}
-                courseId={post.courseId}
-                date={formatData(String(post?.courseDday))}
-              >
-                <DeleteButton type="mypage" postId={String(post.courseId)} />
-                <CopyButton
-                  endpoint={`register/detail/${String(post.courseId)}`}
-                />
-                <ShareKakaoButton
-                  endpoint={`register/detail/${String(post.courseId)}`}
-                />
-              </ContensCard>
-            ))
-          : memberBookmarkedList?.map((post: MyBookMarkSummaryT) => (
-              <ContensCard
-                key={post.courseId}
-                type="post"
-                title={post.courseTitle}
-                text={post.postContent}
-                likeCount={post.courseLikeCount}
-                tag={post.tags}
-                userName={post.memberNickname}
-                thumbnail={post.courseThumbnail}
-                onClick={moveToDetail}
-                courseId={post.courseId}
-                bookmarkStatus
-                postId={post.postId}
-                likeStatus={post.likeStatus}
-                date={manufactureDate(post?.courseUpdatedAt)}
-              >
-                <CopyButton endpoint={`community/${String(post.postId)}`} />
-                <ShareKakaoButton
-                  endpoint={`community/${String(post.postId)}`}
-                />
-              </ContensCard>
-            ))}
+          ? memberCourseList?.map((post: MypCourseSummaryT) => {
+              if (post.courseId !== -1)
+                return (
+                  <ContensCard
+                    key={post.courseId}
+                    type="course"
+                    title={post.courseTitle}
+                    likeCount={post.courseLikeCount}
+                    userName={post.memberNickname}
+                    thumbnail={post.courseThumbnail}
+                    onClick={moveToRegisterDetail}
+                    courseId={post.courseId}
+                    date={formatData(String(post?.courseDday))}
+                  >
+                    <DeleteButton
+                      type="mypage"
+                      postId={String(post.courseId)}
+                    />
+                    <CopyButton
+                      endpoint={`register/detail/${String(post.courseId)}`}
+                    />
+                    <ShareKakaoButton
+                      endpoint={`register/detail/${String(post.courseId)}`}
+                    />
+                  </ContensCard>
+                );
+              return <SkeletonCardContainer length={6} />;
+            })
+          : memberBookmarkedList?.map((post: MyBookMarkSummaryT) => {
+              if (post.courseId !== -1)
+                return (
+                  <ContensCard
+                    key={post.courseId}
+                    type="post"
+                    title={post.courseTitle}
+                    text={post.postContent}
+                    likeCount={post.courseLikeCount}
+                    tag={post.tags}
+                    userName={post.memberNickname}
+                    thumbnail={post.courseThumbnail}
+                    onClick={moveToDetail}
+                    courseId={post.courseId}
+                    bookmarkStatus
+                    postId={post.postId}
+                    likeStatus={post.likeStatus}
+                    date={manufactureDate(post?.courseUpdatedAt)}
+                  >
+                    <CopyButton endpoint={`community/${String(post.postId)}`} />
+                    <ShareKakaoButton
+                      endpoint={`community/${String(post.postId)}`}
+                    />
+                  </ContensCard>
+                );
+              return <SkeletonCardContainer length={6} />;
+            })}
       </CardWrapper>
       <div ref={ref} />
     </FilterWrapper>

--- a/client/src/components/mypage/FilterSection.tsx
+++ b/client/src/components/mypage/FilterSection.tsx
@@ -109,12 +109,13 @@ const FilterSection = ({
                     key={post.courseId}
                     type="course"
                     title={post.courseTitle}
+                    text={post.courseContent}
                     likeCount={post.courseLikeCount}
                     userName={post.memberNickname}
                     thumbnail={post.courseThumbnail}
                     onClick={moveToRegisterDetail}
                     courseId={post.courseId}
-                    date={formatData(String(post?.courseDday))}
+                    date={`${formatData(String(post?.courseDday))} day `}
                   >
                     <DeleteButton
                       type="mypage"

--- a/client/src/components/mypage/UserInfoBox.tsx
+++ b/client/src/components/mypage/UserInfoBox.tsx
@@ -136,7 +136,7 @@ const UserInfoBox = () => {
     if (e.target.value.length < 2 || e.target.value.length > 10) {
       setIsName(false);
       setErrMsg('글자 수를 만족하지 못했습니다.');
-    } else if (e.target.value === '탈퇴한 사용자') {
+    } else if (e.target.value.includes('탈퇴한 사용자')) {
       setIsName(false);
       setErrMsg('사용할 수 없는 닉네임입니다.');
     } else {

--- a/client/src/components/mypage/UserInfoBox.tsx
+++ b/client/src/components/mypage/UserInfoBox.tsx
@@ -101,6 +101,7 @@ const FormBox = styled.form<IsNickNameT>`
 const UserInfoBox = () => {
   const { userData } = useUserInfo();
   const [toggleNickname, setToggleNickname] = useState<boolean>(false);
+  const [errMsg, setErrMsg] = useState<string>('');
   const [isName, setIsName] = useState<boolean>(true);
   const memNicknameRef = useRef<HTMLInputElement>(null);
   const navigator = useNavigate();
@@ -134,6 +135,10 @@ const UserInfoBox = () => {
     dispatch(setUserOAuthActions.paintMemNickname(e.target.value));
     if (e.target.value.length < 2 || e.target.value.length > 10) {
       setIsName(false);
+      setErrMsg('글자 수를 만족하지 못했습니다.');
+    } else if (e.target.value === '탈퇴한 사용자') {
+      setIsName(false);
+      setErrMsg('사용할 수 없는 닉네임입니다.');
     } else {
       setIsName(true);
     }
@@ -187,6 +192,8 @@ const UserInfoBox = () => {
             <FormBox onSubmit={paintNickname}>
               <InputContainer
                 type="title"
+                textType="nickName"
+                text={errMsg}
                 minLength={2}
                 maxLength={10}
                 onChange={onChangeName}

--- a/client/src/components/ui/cards/ContentsCard.tsx
+++ b/client/src/components/ui/cards/ContentsCard.tsx
@@ -172,18 +172,20 @@ const ContensCard = ({
             )}
           </ContensHeader>
           {text && <ContensText>{removeTag(text)}</ContensText>}
-          <Tags>
-            {tag?.map((tagItem: string) => (
-              <TagButton
-                width={cssToken.WIDTH['min-w-fit']}
-                height={cssToken.HEIGHT['h-fit']}
-                isActive={false}
-                key={tagItem}
-              >
-                {tagItem}
-              </TagButton>
-            ))}
-          </Tags>
+          {tag && (
+            <Tags>
+              {tag?.map((tagItem: string) => (
+                <TagButton
+                  width={cssToken.WIDTH['min-w-fit']}
+                  height={cssToken.HEIGHT['h-fit']}
+                  isActive={false}
+                  key={tagItem}
+                >
+                  {tagItem}
+                </TagButton>
+              ))}
+            </Tags>
+          )}
         </TextWrap>
 
         <ThumbnailBox

--- a/client/src/components/ui/input/InputContainer.tsx
+++ b/client/src/components/ui/input/InputContainer.tsx
@@ -28,6 +28,8 @@ const InputContainer = forwardRef(
       maxLength,
       styles,
       type,
+      textType,
+      text,
       isValidate,
       onkeypress,
       defaultValue,
@@ -39,6 +41,8 @@ const InputContainer = forwardRef(
       isValidate?: boolean;
       styles?: TextareaT;
       type?: 'title';
+      textType?: string;
+      text?: string;
       defaultValue?: string;
       // tag 입력 칸과 구분하기 위함
       onkeypress?: (e: KeyboardEvent<HTMLInputElement>) => void;
@@ -58,10 +62,14 @@ const InputContainer = forwardRef(
           defaultValue={defaultValue}
           onChange={onChange}
         />
-        {type === 'title' && !isValidate && (
+        {!textType && type === 'title' && !isValidate && (
           <Text styles={{ color: cssToken.COLOR['red-900'] }}>
             글자 수를 만족하지 못했습니다.
           </Text>
+        )}
+
+        {textType === 'nickName' && !isValidate && (
+          <Text styles={{ color: cssToken.COLOR['red-900'] }}>{text}</Text>
         )}
       </>
     );

--- a/client/src/pages/mypage/MyPage.tsx
+++ b/client/src/pages/mypage/MyPage.tsx
@@ -18,6 +18,7 @@ import getLoginStatus from '../../utils/getLoginStatus';
 import useMovePage from '../../hooks/useMovePage';
 import CircleButton from '../../components/ui/button/CircleButton';
 import Pen from '../../assets/Pen';
+import scrollToTop from '../../utils/scrollToTop';
 
 const Wrapper = styled(FlexDiv)`
   margin-top: 77px;
@@ -66,6 +67,7 @@ const MyPage = () => {
 
   useEffect(() => {
     checkValidEnter();
+    scrollToTop();
   }, [checkValidEnter]);
 
   const memberCourseList = useSelector(


### PR DESCRIPTION
### feat
- 닉네임 '탈퇴한 사용자' 사용 못하도록 유효성 검사 로직 수정했습니다.
   - '탈퇴한 사용자'를 아예 사용하지 못하도록 수정했습니다.
- 날짜 뒤에 day 추가
- 스켈레톤 추가
- 마이페이지 -> 일정 카드에서 태그 영역 아예 없애기
- scroll top 코드 추가

### 작업 화면 - 닉네임 유효성 검사
https://github.com/codestates-seb/seb44_main_006/assets/109754988/e1aaafc4-97c2-4e88-97f3-56ef3ac3b4b8

### 작업 화면 - 날짜 뒤에 day 추가/스켈레톤 추가/일정 카드에서 태그 영역 아예 없애기/scroll top 코드 추가
https://github.com/codestates-seb/seb44_main_006/assets/109754988/e50c5bf8-d6a9-42f9-bc0c-e5e2cee4fad0



