### PR TITLE
fix: 댓글수 전달 추가

### DIFF
--- a/server/src/main/java/com/seb_main_006/config/S3config.java
+++ b/server/src/main/java/com/seb_main_006/config/S3config.java
@@ -1,4 +1,5 @@
 package com.seb_main_006.config;
+
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;

--- a/server/src/main/java/com/seb_main_006/domain/member/dto/MemberBookmarked.java
+++ b/server/src/main/java/com/seb_main_006/domain/member/dto/MemberBookmarked.java
@@ -31,6 +31,8 @@ public class MemberBookmarked {
 
     private Boolean likeStatus;
 
+    private Integer answerCount;
+
     private LocalDateTime courseUpdatedAt;
 
     private LocalDateTime postCreatedAt;
@@ -49,6 +51,7 @@ public class MemberBookmarked {
         this.courseLikeCount = course.getCourseLikeCount();
         this.courseViewCount = course.getCourseViewCount();
         this.likeStatus = likeStatus;
+        this.answerCount = course.getPost().getAnswersInPost().size();
         this.courseUpdatedAt = course.getCourseUpdatedAt();
         this.postCreatedAt = course.getPost().getPostCreatedAt();
         this.tags = course.getPost().getPostTagsInPost().stream().map(postTag -> postTag.getTag().getTagName()).collect(Collectors.toList());

--- a/server/src/main/java/com/seb_main_006/domain/member/service/MemberService.java
+++ b/server/src/main/java/com/seb_main_006/domain/member/service/MemberService.java
@@ -91,7 +91,7 @@ public class MemberService {
         }
 
         // 업데이트시간 기준 정렬(최근 업데이트가 빠른 기준 내림차순 정렬)
-        newMemberCourseList.sort(Comparator.comparing(MemberCourse::getCourseUpdatedAt).reversed());
+        newMemberCourseList.sort(Comparator.comparing(MemberCourse::getCourseDday).reversed());
         newMemberBookmarkedList.sort(Comparator.comparing(MemberBookmarked::getBookmarkId).reversed());
 
         // MypageResponseDto에 값넣고 리턴

--- a/server/src/main/java/com/seb_main_006/domain/post/dto/PostDataForList.java
+++ b/server/src/main/java/com/seb_main_006/domain/post/dto/PostDataForList.java
@@ -37,6 +37,8 @@ public class PostDataForList {
 
     private boolean bookmarkStatus; // 로그인한 유저가 해당 게시글에 대해 즐겨찾기를 했는지 안했는지
 
+    private Integer answerCount;
+
     private LocalDateTime courseUpdatedAt;
 
     private LocalDateTime postCreatedAt;
@@ -56,6 +58,7 @@ public class PostDataForList {
                 .courseViewCount(course.getCourseViewCount())
                 .likeStatus(likeStatus)
                 .bookmarkStatus(bookmarkStatus)
+                .answerCount(course.getPost().getAnswersInPost().size())
                 .courseUpdatedAt(course.getCourseUpdatedAt())
                 .postCreatedAt(course.getPost().getPostCreatedAt())
                 .tags(course.getPost().getPostTagsInPost().stream().map(postTag -> postTag.getTag().getTagName()).collect(Collectors.toList()))


### PR DESCRIPTION
1. 커뮤니티리스트페이지에 댓글 수, 조회수 정보 전달
2. 마이페이지 즐겨찾기탭에 댓글 수, 조회수 정보 전달
3. 마이페이지 내가만든 일정에서 정렬기준 Dday내림차순으로 수정