### PR TITLE
refactor: 검색 기능 쿼리 개수 개선

### DIFF
--- a/server/src/main/java/com/seb_main_006/domain/course/entity/Course.java
+++ b/server/src/main/java/com/seb_main_006/domain/course/entity/Course.java
@@ -61,7 +61,6 @@ public class Course {
     @JoinColumn(name = "member_id")
     private Member member; // member entity와 연관관계 매핑(다:1)
 
-    @BatchSize(size = 100)
     @OneToOne(mappedBy = "course", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private Post post; // post entity와 연관관계 매핑(1:1)
 

--- a/server/src/main/java/com/seb_main_006/domain/course/repository/CourseRepository.java
+++ b/server/src/main/java/com/seb_main_006/domain/course/repository/CourseRepository.java
@@ -14,9 +14,6 @@ import java.util.Set;
 
 public interface CourseRepository extends JpaRepository<Course, Long> {
 
-        @Query("select c from Course c where c.isPosted = true")
-        Page<Course> findAllByPosted(Pageable pageable);
-
         List<Course> findAllByMember(Member member);
 
         @Query("select c from Course c join c.post p where c.isPosted = true " +

--- a/server/src/main/java/com/seb_main_006/domain/post/entity/Post.java
+++ b/server/src/main/java/com/seb_main_006/domain/post/entity/Post.java
@@ -5,6 +5,7 @@ import com.seb_main_006.domain.course.entity.Course;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.BatchSize;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import javax.persistence.*;
@@ -28,14 +29,16 @@ public class Post {
     @CreatedDate
     private LocalDateTime postCreatedAt; // 코스 생성일자
 
-    @OneToOne
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "course_id")
     private Course course; // course entity와 연관관계 매핑(1:1)
 
-    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
+    @BatchSize(size = 50)
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private List<PostTag> postTagsInPost = new ArrayList<>(); // postTag entity와 연관관계 매핑(1:다)
 
-    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
+    @BatchSize(size = 50)
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private List<Answer> answersInPost = new ArrayList<>(); // answer entity와 연관관계 매핑(1:다)
 
 }

--- a/server/src/main/java/com/seb_main_006/domain/post/entity/PostTag.java
+++ b/server/src/main/java/com/seb_main_006/domain/post/entity/PostTag.java
@@ -16,11 +16,11 @@ public class PostTag {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long postTagId; // 게시글-태그 식별자, 기본키
 
-    @ManyToOne(cascade = CascadeType.ALL)
+    @ManyToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     @JoinColumn(name = "post_id")
     private Post post; // post entity와 연관관계 매핑(다:1)
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "tag_id")
     private Tag tag; // tag entity와 연관관계 매핑(다:1)
 

--- a/server/src/main/java/com/seb_main_006/domain/post/repository/PostRepository.java
+++ b/server/src/main/java/com/seb_main_006/domain/post/repository/PostRepository.java
@@ -13,7 +13,7 @@ import java.util.Set;
 public interface PostRepository extends JpaRepository<Post, Long> {
     Optional<Post> findByCourse(Course course);
 
-    @Query("select distinct c from Post p join p.course c " +
+    @Query("select distinct c from Course c join fetch c.post p join fetch c.member m join fetch m.roles r " +
             "where replace(c.courseTitle, ' ', '') like %:inputWord%")
     List<Course> searchCourseOrderByWord(@Param("inputWord") String inputWord);
 }

--- a/server/src/main/java/com/seb_main_006/domain/post/repository/PostTagRepository.java
+++ b/server/src/main/java/com/seb_main_006/domain/post/repository/PostTagRepository.java
@@ -25,7 +25,7 @@ public interface PostTagRepository extends JpaRepository<PostTag, Long> {
     Page<Course> findByTagInOrderByLikeCount(@Param("tagList") List<Tag> tagList, Pageable pageable);
 
     @Query("select distinct c " +
-            "from PostTag pt join pt.post p join pt.post.course c " +
+            "from Course c join fetch c.post p join fetch p.postTagsInPost pt " +
             "where pt.tag in :tagList ")
     List<Course> findByTagInOrderByWord(@Param("tagList") List<Tag> tagList);
 


### PR DESCRIPTION
- 일정 제목 검색 시 join fetch 를 통해 N+1 문제 개선
- 필터링된 게시글(일정)에서 현재 조회 주체인 멤버의 좋아요, 즐겨찾기를 리스트 순회하며 각각 DB 조회하던 로직애서 JPA의 객체 탐색을 통해 한번에 조회하도록 변경함으로써 리스트 수만큼 쿼리 수 개선