### PR TITLE
refactor: 일정 순서 변경했을 때 마지막 일정도 변경

### DIFF
--- a/client/src/components/schedule/DirectSearch.tsx
+++ b/client/src/components/schedule/DirectSearch.tsx
@@ -20,7 +20,7 @@ const DirectSearch = () => {
 
   useEffect(() => {
     dispatch(selectedIdActions.setCategoryId(''));
-    dispatch(selectedIdActions.setTagId(''));
+    dispatch(selectedIdActions.setTagId('1'));
   }, [dispatch]);
 
   const handleSubmit = (

--- a/client/src/components/schedule/ScheduleListBox.tsx
+++ b/client/src/components/schedule/ScheduleListBox.tsx
@@ -26,6 +26,9 @@ const ScheduleListBox = () => {
     const targetSchedules = copySchedules.splice(source.index, 1);
     copySchedules.splice(destination.index, 0, ...targetSchedules);
 
+    dispatch(
+      scheduleListActions.setLastItem(copySchedules[copySchedules.length - 1])
+    );
     dispatch(scheduleListActions.updateList(copySchedules));
   };
 

--- a/client/src/pages/schedule/ScheduleRegister.tsx
+++ b/client/src/pages/schedule/ScheduleRegister.tsx
@@ -5,7 +5,7 @@ import { useQuery } from '@tanstack/react-query';
 
 import { IScheduleListItem, PlacesSearchResultItem } from '../../types/type';
 import { RootState } from '../../store';
-import ScheduleBox from '../../components/schedule/Schedulebox';
+import ScheduleBox from '../../components/schedule/ScheduleBox';
 import cssToken from '../../styles/cssToken';
 import { MarkerOff } from '../../components/map/index';
 import ScheduleCreateModal from '../../components/schedule/ScheduleCreateModal';

--- a/client/src/store/scheduleList-slice.ts
+++ b/client/src/store/scheduleList-slice.ts
@@ -52,6 +52,9 @@ const scheduleListSlice = createSlice({
     updateList(state, action: PayloadAction<TScheduleList>) {
       state.list = action.payload;
     },
+    setLastItem(state, action: PayloadAction<IScheduleListItem>) {
+      state.lastItem = action.payload;
+    },
     resetList(state) {
       state.list = [];
       state.imageUrl = '';


### PR DESCRIPTION
## 작업 사항
- refactor: 일정 순서 변경했을 때 마지막 일정도 변경
- fix: 직접검색에서 카테고리 검색갔을 때 태그 active 활성화