### PR TITLE
fix: RefreshToken 재발급 로직 수정

### DIFF
--- a/server/src/main/java/com/seb_main_006/global/auth/redis/RefreshToken.java
+++ b/server/src/main/java/com/seb_main_006/global/auth/redis/RefreshToken.java
@@ -8,7 +8,6 @@ import java.util.List;
 
 @Builder
 @Getter
-@Setter
 @AllArgsConstructor
 @NoArgsConstructor
 @RedisHash(value = "refresh", timeToLive = 1209600)

--- a/server/src/main/java/com/seb_main_006/global/auth/redis/RefreshToken.java
+++ b/server/src/main/java/com/seb_main_006/global/auth/redis/RefreshToken.java
@@ -1,9 +1,6 @@
 package com.seb_main_006.global.auth.redis;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.redis.core.RedisHash;
 import org.springframework.data.redis.core.index.Indexed;
@@ -11,6 +8,7 @@ import java.util.List;
 
 @Builder
 @Getter
+@Setter
 @AllArgsConstructor
 @NoArgsConstructor
 @RedisHash(value = "refresh", timeToLive = 1209600)

--- a/server/src/main/java/com/seb_main_006/global/auth/service/AuthService.java
+++ b/server/src/main/java/com/seb_main_006/global/auth/service/AuthService.java
@@ -86,6 +86,7 @@ public class AuthService {
     public TokenDto reissueV2(String refreshToken, String userEmail) throws JsonProcessingException {
         log.info("refreshToken = {}", refreshToken);
 
+        // Redis에서 전달받은 refreshToken으로 조회한 결과가 없다면 예외 발생
         RefreshToken findRefreshToken = refreshTokenRedisRepository.findByRefreshToken(refreshToken);
         if (findRefreshToken == null) {
             throw new BusinessLogicException(ExceptionCode.TOKEN_EXPIRED);
@@ -119,7 +120,7 @@ public class AuthService {
                 .id(userEmail)
                 .username(userEmail)
                 .authorities(authorities)
-                .refreshToken(refreshToken)
+                .refreshToken(newAccessToken)
                 .build());
 
         return new TokenDto(newAccessToken, newRefreshToken);

--- a/server/src/main/java/com/seb_main_006/global/auth/service/AuthService.java
+++ b/server/src/main/java/com/seb_main_006/global/auth/service/AuthService.java
@@ -86,6 +86,11 @@ public class AuthService {
     public TokenDto reissueV2(String refreshToken, String userEmail) throws JsonProcessingException {
         log.info("refreshToken = {}", refreshToken);
 
+        RefreshToken findRefreshToken = refreshTokenRedisRepository.findByRefreshToken(refreshToken);
+        if (findRefreshToken == null) {
+            throw new BusinessLogicException(ExceptionCode.TOKEN_EXPIRED);
+        }
+
         String newRefreshToken = refreshToken; // 재발급이 필요하지 않으면 기존 RTK 가 전달되도록 초기값 설정
 
         // RTK 남은 만료시간 계산
@@ -105,8 +110,17 @@ public class AuthService {
         }
 
         // AccessToken 재발급 후 ATK, RTK TokenDto로 리턴
-        List<String> authorities = refreshTokenRedisRepository.findByRefreshToken(refreshToken).getAuthorities();
+        List<String> authorities = findRefreshToken.getAuthorities();
         String newAccessToken = jwtTokenizer.generateAccessToken(userEmail, authorities);
+
+        // 기존 RefreshToken 삭제 & newRefreshToken Redis에 새로 저장
+        refreshTokenRedisRepository.delete(findRefreshToken);
+        refreshTokenRedisRepository.save(RefreshToken.builder()
+                .id(userEmail)
+                .username(userEmail)
+                .authorities(authorities)
+                .refreshToken(refreshToken)
+                .build());
 
         return new TokenDto(newAccessToken, newRefreshToken);
     }


### PR DESCRIPTION
#### 1. 전달받은 RefreshToken으로 Redis에 저장된 RefreshToken을 조회했을 때 조회 내역이 없는 경우에 대한 예외처리
- Redis에서 RefreshToken이 조회되지 않는다면 signature 외의 값이 변조된 상태의 토큰이라는 의미
- signature 에 대한 검증은 filter에서 진행되므로 reissue 핸들러까지 도달했다면 signature 검증은 통과된 상태.
- 따라서 Redis에서 조회되는 RefreshToken 값이 없을 경우 다시 로그인하도록 만료 예외로 응답 (410)

#### 2. RefreshToken을 재발급할 때 Redis에 기존 RefreshToken 삭제 후 새로 저장