### PR TITLE
refactor: PlaceList, ScheduleListBox 컴포넌트에 React.memo 적용

### DIFF
--- a/client/src/components/map/PlaceList.tsx
+++ b/client/src/components/map/PlaceList.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef } from 'react';
+import React, { useCallback, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { styled } from 'styled-components';
 import { v4 as uuidv4 } from 'uuid';
@@ -168,4 +168,4 @@ const PlaceList = ({
   );
 };
 
-export default PlaceList;
+export default React.memo(PlaceList);

--- a/client/src/components/schedule/ScheduleListBox.tsx
+++ b/client/src/components/schedule/ScheduleListBox.tsx
@@ -1,6 +1,7 @@
 import { styled } from 'styled-components';
 import { useDispatch, useSelector } from 'react-redux';
 import { DragDropContext, Draggable, DropResult } from 'react-beautiful-dnd';
+import React, { useMemo } from 'react';
 
 import cssToken from '../../styles/cssToken';
 import { RootState } from '../../store';
@@ -16,12 +17,13 @@ const Wrapper = styled.div`
 const ScheduleListBox = () => {
   const dispatch = useDispatch();
   const schedules = useSelector((state: RootState) => state.scheduleList.list);
+  const memoSchedules = useMemo(() => schedules, [schedules]);
 
   const onDragEnd = ({ source, destination }: DropResult) => {
     if (!destination) return;
 
     const copySchedules = JSON.parse(
-      JSON.stringify(schedules)
+      JSON.stringify(memoSchedules)
     ) as TScheduleList;
     const targetSchedules = copySchedules.splice(source.index, 1);
     copySchedules.splice(destination.index, 0, ...targetSchedules);
@@ -38,7 +40,7 @@ const ScheduleListBox = () => {
         <StrictModeDroppable droppableId="schedules">
           {(provided) => (
             <div ref={provided.innerRef} {...provided.droppableProps}>
-              {schedules.map((schedule: IScheduleListItem, idx: number) => (
+              {memoSchedules.map((schedule: IScheduleListItem, idx: number) => (
                 <Draggable
                   key={schedule.id}
                   draggableId={schedule.id}
@@ -70,4 +72,4 @@ const ScheduleListBox = () => {
   );
 };
 
-export default ScheduleListBox;
+export default React.memo(ScheduleListBox);


### PR DESCRIPTION
## 작업 사항
PlaceList 컴포넌트와 ScheduleListBox 컴포넌트에 React.memo를 적용하여 리렌더링을 제거했습니다.

## 영상

- 개선 전
![GIFMaker_me](https://github.com/codestates-seb/seb44_main_006/assets/77836614/cc3d0cbe-e985-488d-80c1-a967ea703b13)


- 개선 후
![GIFMaker_me (2) (1)](https://github.com/codestates-seb/seb44_main_006/assets/77836614/90e2fb82-4c84-4d9b-911b-d4f853203e66)

